### PR TITLE
Update to 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Discord.zig
 
 A high-performance bleeding edge Discord library in Zig, featuring full API coverage, sharding support, and fine-tuned parsing
+
 * Sharding Support: Ideal for large bots, enabling distributed load handling.
 * 100% API Coverage & Fully Typed: Offers complete access to Discord's API with strict typing for reliable and safe code.
 * High Performance: Faster than whichever library you can name (WIP)
@@ -39,11 +40,14 @@ pub fn main() !void {
         .intents = Discord.Intents.fromRaw(53608447),
         .token = std.posix.getenv("DISCORD_TOKEN").?,
         .run = .{ .message_create = &message_create, .ready = &ready },
+        .options = .{},
+        .log = .yes,
     });
 }
 ```
 
 ## Installation
+
 ```zig
 // In your build.zig file
 const exe = b.addExecutable(.{
@@ -61,11 +65,14 @@ exe.root_module.addImport("discord.zig", dzig.module("discord.zig"));
 **Warning**: the library is intended to be used with the latest dev version of Zig.
 
 ## contributing
+
 Contributions are welcome! Please open an issue or pull request if you'd like to help improve the library.
-* Support server: https://discord.gg/RBHkBt7nP5
-* The original repo: https://codeberg.org/yuzu/discord.zig
+
+* Support server: <https://discord.gg/RBHkBt7nP5>
+* The original repo: <https://codeberg.org/yuzu/discord.zig>
 
 ## general roadmap
+
 | Task                                                        | Status |
 |-------------------------------------------------------------|--------|
 | stablish good sharding support with buckets                 | ✅     |
@@ -76,6 +83,7 @@ Contributions are welcome! Please open an issue or pull request if you'd like to
 | get a cool logo                                             | ❌     |
 
 ## missing events right now
+
 | Event                                  | Support |
 |----------------------------------------|---------|
 | voice_channel_effect_send              | ❌      |
@@ -83,6 +91,7 @@ Contributions are welcome! Please open an issue or pull request if you'd like to
 | voice_server_update                    | ❌      |
 
 ## http methods missing
+
 | Endpoint                               | Support |
 |----------------------------------------|---------|
 | Audit log                              | ❌      |

--- a/build.zig
+++ b/build.zig
@@ -16,7 +16,7 @@ pub fn build(b: *std.Build) void {
 
     const zlib = b.dependency("zlib", .{});
 
-    const deque = b.dependency("zig-deque", .{
+    const deque = b.dependency("zig_deque", .{
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -15,7 +15,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    //.minimum_zig_version = "0.11.0",
+    .minimum_zig_version = "0.14.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -28,8 +28,8 @@
             .hash = "1220cd041e8d04f1da9d6f46d0438f4e6809b113ba3454fffdaae96b59d2b35a6b2b",
         },
         .websocket = .{
-            .url = "https://github.com/yuzudev/websocket.zig/archive/refs/heads/master.zip",
-            .hash = "12207c03624f9f5a1c444bde3d484a9b1e927a902067fded98364b714de412d318e0",
+            .url = "https://github.com/karlseguin/websocket.zig/archive/refs/heads/master.zip",
+            .hash = "websocket-0.1.0-ZPISdXNIAwCXG7oHBj4zc1CfmZcDeyR6hfTEOo8_YI4r",
         },
         .zig_deque = .{
             .url = "https://github.com/asier-ochoa/zig-deque/archive/refs/heads/0.14.0-update.zip",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,7 +6,7 @@
     //
     // It is redundant to include "zig" in this name because it is already
     // within the Zig package namespace.
-    .name = "discord.zig",
+    .name = "discord",
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -23,10 +23,6 @@
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
     .dependencies = .{
-        .@"zig-deque" = .{
-            .url = "https://github.com/magurotuna/zig-deque/archive/refs/heads/main.zip",
-            .hash = "1220d1bedf7d5cfc7475842b3d4e8f03f1308be2e724a036677cceb5c4db13c3da3d",
-        },
         .zlib = .{
             .url = "https://github.com/yuzudev/zig-zlib/archive/refs/heads/main.zip",
             .hash = "1220cd041e8d04f1da9d6f46d0438f4e6809b113ba3454fffdaae96b59d2b35a6b2b",
@@ -34,6 +30,10 @@
         .websocket = .{
             .url = "https://github.com/yuzudev/websocket.zig/archive/refs/heads/master.zip",
             .hash = "12207c03624f9f5a1c444bde3d484a9b1e927a902067fded98364b714de412d318e0",
+        },
+        .zig_deque = .{
+            .url = "https://github.com/asier-ochoa/zig-deque/archive/refs/heads/0.14.0-update.zip",
+            .hash = "zig_deque-0.1.0-kaJoTgBDAAD7AXh-BHbBErpP2IzjKCUAX5-zJKpK3Yjm",
         },
     },
     .paths = .{

--- a/src/json.zig
+++ b/src/json.zig
@@ -857,7 +857,7 @@ pub const BailingAllocator = struct {
     const Mem = struct {
         ptr: [*]u8,
         len: usize,
-        ptr_align: u8,
+        ptr_align: std.mem.Alignment,
     };
 
     fn init(child_allocator: std.mem.Allocator) BailingAllocator {
@@ -889,7 +889,7 @@ pub const BailingAllocator = struct {
         self.responsibilities.deinit(self.child_allocator);
     }
 
-    fn alloc(ctx: *anyopaque, len: usize, ptr_align: u8, _: usize) ?[*]u8 {
+    fn alloc(ctx: *anyopaque, len: usize, ptr_align: std.mem.Alignment, _: usize) ?[*]u8 {
         const self: *BailingAllocator = @ptrCast(@alignCast(ctx));
         self.responsibilities.ensureUnusedCapacity(self.child_allocator, 1) catch return null;
         const ptr = self.child_allocator.rawAlloc(len, ptr_align, @returnAddress()) orelse return null;
@@ -897,7 +897,7 @@ pub const BailingAllocator = struct {
         return ptr;
     }
 
-    fn resize(ctx: *anyopaque, buf: []u8, buf_align: u8, new_len: usize, _: usize) bool {
+    fn resize(ctx: *anyopaque, buf: []u8, buf_align: std.mem.Alignment, new_len: usize, _: usize) bool {
         const self: *BailingAllocator = @ptrCast(@alignCast(ctx));
         const res = self.child_allocator.rawResize(buf, buf_align, new_len, @returnAddress());
         if (res) {
@@ -908,7 +908,7 @@ pub const BailingAllocator = struct {
         return res;
     }
 
-    fn free(ctx: *anyopaque, buf: []u8, buf_align: u8, _: usize) void {
+    fn free(ctx: *anyopaque, buf: []u8, buf_align: std.mem.Alignment, _: usize) void {
         const self: *BailingAllocator = @ptrCast(@alignCast(ctx));
         self.child_allocator.rawFree(buf, buf_align, @returnAddress());
 

--- a/src/json.zig
+++ b/src/json.zig
@@ -1276,7 +1276,7 @@ pub fn Record(comptime T: type) type {
     return struct {
         map: std.StringHashMapUnmanaged(T),
         pub fn json(allocator: mem.Allocator, value: JsonType) !@This() {
-            var map: std.StringHashMapUnmanaged(T) = .init;
+            var map: std.StringHashMapUnmanaged(T) = .empty;
 
             var iterator = value.object.iterator();
 

--- a/src/json.zig
+++ b/src/json.zig
@@ -1146,7 +1146,7 @@ pub fn parseInto(comptime T: type, allocator: mem.Allocator, value: JsonType) Er
                         const item = try parseInto(ptrInfo.child, allocator, jsonval);
                         arraylist.appendAssumeCapacity(item);
                     }
-                    if (ptrInfo.sentinel) |some| {
+                    if (ptrInfo.sentinel_ptr) |some| {
                         const sentinel = @as(*align(1) const ptrInfo.child, @ptrCast(some)).*;
                         return try arraylist.toOwnedSliceSentinel(sentinel);
                     }
@@ -1160,7 +1160,7 @@ pub fn parseInto(comptime T: type, allocator: mem.Allocator, value: JsonType) Er
                         for (string) |char|
                             arraylist.appendAssumeCapacity(char);
 
-                        if (ptrInfo.sentinel) |some| {
+                        if (ptrInfo.sentinel_ptr) |some| {
                             const sentinel = @as(*align(1) const ptrInfo.child, @ptrCast(some)).*;
                             return try arraylist.toOwnedSliceSentinel(sentinel);
                         }

--- a/src/json.zig
+++ b/src/json.zig
@@ -1132,13 +1132,13 @@ pub fn parseInto(comptime T: type, allocator: mem.Allocator, value: JsonType) Er
             }
         },
         .pointer => |ptrInfo| switch (ptrInfo.size) {
-            .One => {
+            .one => {
                 // we simply allocate the type and return an address instead of just returning the type
                 const r: *ptrInfo.child = try allocator.create(ptrInfo.child);
                 r.* = try parseInto(ptrInfo.child, allocator, value);
                 return r;
             },
-            .Slice => switch (value) {
+            .slice => switch (value) {
                 .array => |array| {
                     var arraylist: std.ArrayList(ptrInfo.child) = .init(allocator);
                     try arraylist.ensureUnusedCapacity(array.len);

--- a/src/structures/partial.zig
+++ b/src/structures/partial.zig
@@ -33,7 +33,7 @@ pub fn Partial(comptime T: type) type {
                 const aligned_ptr: *align(field.alignment) const anyopaque = @alignCast(@ptrCast(&default_value));
                 const optional_field: [1]std.builtin.Type.StructField = [_]std.builtin.Type.StructField{.{
                     .alignment = field.alignment,
-                    .default_value = aligned_ptr,
+                    .default_value_ptr = aligned_ptr,
                     .is_comptime = false,
                     .name = field.name,
                     .type = optional_type,

--- a/src/structures/shared.zig
+++ b/src/structures/shared.zig
@@ -30,6 +30,10 @@ pub const PremiumTypes = enum {
     NitroClassic,
     Nitro,
     NitroBasic,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/user#user-object-user-flags
@@ -307,12 +311,20 @@ pub const ActivityFlags = packed struct {
 pub const IntegrationExpireBehaviors = enum {
     RemoveRole,
     Kick,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum
 pub const TeamMembershipStates = enum(u4) {
     Invited = 1,
     Accepted = 2,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/topics/oauth2#application-application-flags
@@ -369,6 +381,10 @@ pub const MessageComponentTypes = enum(u4) {
     SelectMenuUsersAndRoles,
     /// Select menu for channels
     SelectMenuChannels,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 pub const TextStyles = enum(u4) {
@@ -376,6 +392,10 @@ pub const TextStyles = enum(u4) {
     Short = 1,
     /// Intended for much longer inputs
     Paragraph = 2,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/interactions/message-components#buttons-button-styles
@@ -392,6 +412,10 @@ pub const ButtonStyles = enum(u4) {
     Link,
     /// A blurple button to show a Premium item in the shop
     Premium,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/channel#allowed-mentions-object-allowed-mention-types
@@ -412,6 +436,10 @@ pub const WebhookTypes = enum(u4) {
     ChannelFollower,
     /// Application webhooks are webhooks used with Interactions
     Application,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/channel#embed-object-embed-types
@@ -432,6 +460,10 @@ pub const DefaultMessageNotificationLevels = enum {
     AllMessages,
     /// Members will receive notifications only for messages that \@mention them by default
     OnlyMentions,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level
@@ -442,6 +474,10 @@ pub const ExplicitContentFilterLevels = enum {
     MembersWithoutRoles,
     /// Media content sent by all members will be scanned
     AllMembers,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/guild#guild-object-verification-level
@@ -456,6 +492,10 @@ pub const VerificationLevels = enum {
     High,
     /// Must have a verified phone number
     VeryHigh,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/guild#guild-object-guild-features
@@ -520,6 +560,10 @@ pub const MfaLevels = enum {
     None,
     /// Guild has a 2FA requirement for moderation actions
     Elevated,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags
@@ -553,6 +597,10 @@ pub const PremiumTiers = enum {
     Tier2,
     /// Guild has unlocked Server Boost level 3 perks
     Tier3,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level
@@ -561,6 +609,10 @@ pub const GuildNsfwLevel = enum {
     Explicit,
     Safe,
     AgeRestricted,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/channel#channel-object-channel-types
@@ -606,6 +658,10 @@ pub const ChannelTypes = packed struct {
 pub const OverwriteTypes = enum {
     Role,
     Member,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 pub const VideoQualityModes = enum(u4) {
@@ -613,6 +669,10 @@ pub const VideoQualityModes = enum(u4) {
     Auto = 1,
     /// 720p
     Full,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-types
@@ -623,6 +683,10 @@ pub const ActivityTypes = enum(u4) {
     Watching = 3,
     Custom = 4,
     Competing = 5,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/channel#message-object-message-types
@@ -664,6 +728,10 @@ pub const MessageTypes = enum(u8) {
     GuildIncidentReportFalseAlarm,
     PurchaseNotification = 44,
     PollResult = 46,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/channel#message-object-message-activity-types
@@ -672,6 +740,10 @@ pub const MessageActivityTypes = enum(u4) {
     Spectate = 2,
     Listen = 3,
     JoinRequest = 5,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-types
@@ -680,6 +752,10 @@ pub const StickerTypes = enum(u4) {
     Standard = 1,
     /// a sticker uploaded to a guild for the guild's members
     Guild = 2,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-format-types
@@ -688,6 +764,10 @@ pub const StickerFormatTypes = enum(u4) {
     APng,
     Lottie,
     Gif,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/interactions/slash-commands#interaction-interactiontype
@@ -697,6 +777,10 @@ pub const InteractionTypes = enum(u4) {
     MessageComponent = 3,
     ApplicationCommandAutocomplete = 4,
     ModalSubmit = 5,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptiontype
@@ -712,6 +796,10 @@ pub const ApplicationCommandOptionTypes = enum(u4) {
     Mentionable,
     Number,
     Attachment,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events
@@ -842,17 +930,29 @@ pub const AuditLogEvents = enum(u4) {
     HomeSettingsCreate = 190,
     /// Guild Server Guide was updated
     HomeSettingsUpdate,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 pub const ScheduledEventPrivacyLevel = enum(u4) {
     /// the scheduled event is only accessible to guild members
     GuildOnly = 2,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 pub const ScheduledEventEntityType = enum(u4) {
     StageInstance = 1,
     Voice,
     External,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 pub const ScheduledEventStatus = enum(u4) {
@@ -860,12 +960,20 @@ pub const ScheduledEventStatus = enum(u4) {
     Active,
     Completed,
     Canceled,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/resources/invite#invite-object-target-user-types
 pub const TargetTypes = enum(u4) {
     Stream = 1,
     EmbeddedApplication,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 pub const ApplicationCommandTypes = enum(u4) {
@@ -877,12 +985,20 @@ pub const ApplicationCommandTypes = enum(u4) {
     Message,
     /// A UI-based command that represents the primary way to invoke an app's Activity
     PrimaryEntryPoint,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 pub const ApplicationCommandPermissionTypes = enum(u4) {
     Role = 1,
     User,
     Channel,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags
@@ -1416,6 +1532,10 @@ pub const InteractionResponseTypes = enum(u4) {
     /// @remarks
     /// Only available for apps with Activities enabled
     LaunchActivity = 12,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 pub const SortOrderTypes = enum {
@@ -1423,6 +1543,10 @@ pub const SortOrderTypes = enum {
     LatestActivity,
     /// Sort forum posts by creation time (from most recent to oldest)
     CreationDate,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 pub const ForumLayout = enum {
@@ -1432,6 +1556,10 @@ pub const ForumLayout = enum {
     ListView,
     /// Display posts as a collection of tiles.
     GalleryView,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };
 
 /// https://discord.com/developers/docs/reference#image-formatting
@@ -1620,4 +1748,8 @@ pub const InteractionContextType = enum {
     BotDm,
     /// Interaction can be used within Group DMs and DMs other than the app's bot user
     PrivateChannel,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.write(@intFromEnum(self));
+    }
 };

--- a/src/structures/shared.zig
+++ b/src/structures/shared.zig
@@ -558,6 +558,8 @@ pub const GuildFeatures = enum {
     SOUNDBOARD,
     /// guild has access to set 384kbps bitrate in voice (previously VIP voice servers)
     VIP_REGIONS,
+    /// guid has channel emojis (not in official documentation)
+    CHANNEL_ICON_EMOJIS_GENERATED,
 };
 
 /// https://discord.com/developers/docs/resources/guild#guild-object-mfa-level

--- a/src/structures/shared.zig
+++ b/src/structures/shared.zig
@@ -542,16 +542,22 @@ pub const GuildFeatures = enum {
     ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE,
     /// Guild has enabled role subscriptions.
     ROLE_SUBSCRIPTIONS_ENABLED,
-    /// Guild has set up auto moderation rules
-    AUTO_MODERATION,
     /// Guild has paused invites, preventing new users from joining
     INVITES_DISABLED,
-    /// Guild has access to set an animated guild banner image
-    ANIMATED_BANNER,
-    /// Guild has disabled alerts for join raids in the configured safety alerts channel
-    RAID_ALERTS_DISABLED,
     /// Guild is using the old permissions configuration behavior
     APPLICATION_COMMAND_PERMISSIONS_V2,
+    /// guild has access to set an animated guild banner image
+    ANIMATED_BANNER,
+    /// guild has set up auto moderation rules
+    AUTO_MODERATION,
+    /// guild has increased custom soundboard sound slots
+    MORE_SOUNDBOARD,
+    /// guild has disabled alerts for join raids in the configured safety alerts channel
+    RAID_ALERTS_DISABLED,
+    /// guild has created soundboard sounds
+    SOUNDBOARD,
+    /// guild has access to set 384kbps bitrate in voice (previously VIP voice servers)
+    VIP_REGIONS,
 };
 
 /// https://discord.com/developers/docs/resources/guild#guild-object-mfa-level


### PR DESCRIPTION
I don't know if you wish to use these, but here are the updates needed in order to compile the (slightly modified) example in the readme for 0.14.0.

I believe here's a list of all the changes:

- `build.zig.zon` the name cannot have a '.'
- switch to use a different fork of `zig-deque` that has 0.14.0
- base `websocket-zig` has been updated to 0.14.0
- various changes to json with updates to types
- updated minimum version (as will not support earlier zig versions)
- updated example